### PR TITLE
Fix jax 0.6.0 compatibility

### DIFF
--- a/waymax/agents/expert.py
+++ b/waymax/agents/expert.py
@@ -50,7 +50,7 @@ def infer_expert_action(
   next_logged_traj = datatypes.dynamic_slice(  # pytype: disable=wrong-arg-types  # jax-ndarray
       simulator_state.log_trajectory, simulator_state.timestep + 1, 1, axis=-1
   )
-  combined_traj = jax.tree_map(
+  combined_traj = jax.tree_util.tree_map(
       lambda x, y: jnp.concatenate([x, y], axis=-1),
       prev_sim_traj,
       next_logged_traj,

--- a/waymax/agents/waypoint_following_agent.py
+++ b/waymax/agents/waypoint_following_agent.py
@@ -634,7 +634,7 @@ def _add_headway_waypoints(
     new_item = jnp.tile(item[..., -1:], tile_shape)
     return jnp.concatenate([item, new_item], axis=-1)
 
-  new_traj = jax.tree_map(_repeat_last, traj)
+  new_traj = jax.tree_util.tree_map(_repeat_last, traj)
   new_traj = new_traj.replace(
       x=new_xy_points[..., 0],
       y=new_xy_points[..., 1],

--- a/waymax/agents/waypoint_following_agent_test.py
+++ b/waymax/agents/waypoint_following_agent_test.py
@@ -60,14 +60,14 @@ class WaypointFollowingAgentTest(tf.test.TestCase):
         width=jnp.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
         height=jnp.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
     )
-    self.test_traj = jax.tree_map(lambda x: x[jnp.newaxis], test_traj)
+    self.test_traj = jax.tree_util.tree_map(lambda x: x[jnp.newaxis], test_traj)
     test_traj_with_invalid = test_traj.replace(
         x=jnp.array([0.0, 1.0, -1.0, -1.0, 4.0, 5.0]),
         y=jnp.array([-1.0, 0.0, -1.0, -1.0, 1.0, 2.0]),
         z=jnp.array([0.0, 0.0, -1.0, -1.0, 0.0, 0.0]),
         valid=jnp.array([1.0, 1.0, 0.0, 0.0, 1.0, 1.0], dtype=bool),
     )
-    self.test_traj_with_invalid = jax.tree_map(
+    self.test_traj_with_invalid = jax.tree_util.tree_map(
         lambda x: x[jnp.newaxis], test_traj_with_invalid
     )
     self.config = _config.DatasetConfig(
@@ -220,7 +220,7 @@ class IDMRoutePolicyTest(tf.test.TestCase, parameterized.TestCase):
         width=jnp.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
         height=jnp.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
     )
-    self.test_traj = jax.tree_map(lambda x: x[jnp.newaxis], test_traj)
+    self.test_traj = jax.tree_util.tree_map(lambda x: x[jnp.newaxis], test_traj)
 
     self.config = _config.DatasetConfig(
         path=TEST_DATA_PATH,
@@ -362,7 +362,7 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
         width=jnp.array([1, 1, 1], dtype=jnp.float32),
         height=jnp.array([1, 1, 1], dtype=jnp.float32),
     )
-    traj = jax.tree_map(lambda x: x[jnp.newaxis], traj)
+    traj = jax.tree_util.tree_map(lambda x: x[jnp.newaxis], traj)
 
     new_traj = waypoint_following_agent._add_headway_waypoints(
         traj, distance=2.0, num_points=2
@@ -380,7 +380,7 @@ class UtilFunctionsTest(tf.test.TestCase, parameterized.TestCase):
         width=jnp.array([1, 1, 1, 1, 1]),
         height=jnp.array([1, 1, 1, 1, 1]),
     )
-    expected_traj = jax.tree_map(lambda x: x[jnp.newaxis], expected_traj)
+    expected_traj = jax.tree_util.tree_map(lambda x: x[jnp.newaxis], expected_traj)
 
     traj_7dof = new_traj.stack_fields(
         ['x', 'y', 'vel_x', 'vel_y', 'length', 'width', 'yaw']

--- a/waymax/dynamics/abstract_dynamics_test.py
+++ b/waymax/dynamics/abstract_dynamics_test.py
@@ -71,7 +71,7 @@ class AbstractDynamicsTest(tf.test.TestCase, parameterized.TestCase):
         width=jnp.zeros((batch_size, objects, timesteps)),
         height=jnp.zeros((batch_size, objects, timesteps)),
     )
-    sim_traj = jax.tree_map(jnp.ones_like, log_traj)
+    sim_traj = jax.tree_util.tree_map(jnp.ones_like, log_traj)
     is_controlled = jnp.array([[True, False, False, False, False]])
     update = datatypes.TrajectoryUpdate(
         x=1 * jnp.ones((batch_size, objects, 1)),

--- a/waymax/dynamics/state_dynamics_test.py
+++ b/waymax/dynamics/state_dynamics_test.py
@@ -46,7 +46,7 @@ class StateDynamicsTest(parameterized.TestCase, tf.test.TestCase):
         height=jnp.zeros((batch_size, objects, timesteps)),
     )
     # Initialize the simulated trajectory to all one-valued attributes.
-    sim_traj = jax.tree_map(jnp.ones_like, log_traj)
+    sim_traj = jax.tree_util.tree_map(jnp.ones_like, log_traj)
     # Set the 2nd object (index 1) to be controlled.
     is_controlled = jnp.array([[False, True, False, False, False]])
     # Create a test action with value (1, 2, 3, 4, 5)
@@ -69,7 +69,7 @@ class StateDynamicsTest(parameterized.TestCase, tf.test.TestCase):
         next_traj, timestep + 1, 1, axis=-1
     )
     # Shape: (batch_size=1, timesteps=1)
-    controlled_traj = jax.tree_map(lambda x: x[is_controlled], traj_at_timestep)
+    controlled_traj = jax.tree_util.tree_map(lambda x: x[is_controlled], traj_at_timestep)
 
     with self.subTest('ControlledTrajIsCorrect'):
       self.assertAllClose(

--- a/waymax/env/base_environment_test.py
+++ b/waymax/env/base_environment_test.py
@@ -95,7 +95,7 @@ class BaseEnvironmentTest(tf.test.TestCase, parameterized.TestCase):
         timestamp_micros=jnp.ones_like(traj_value).astype(jnp.int32),
         valid=jnp.ones_like(traj_value).astype(jnp.bool_),
     )
-    log_traj = jax.tree_map(
+    log_traj = jax.tree_util.tree_map(
         lambda x: jnp.zeros_like(x).astype(x.dtype), sim_traj
     )
     roadgraph_points = datatypes.RoadgraphPoints(

--- a/waymax/env/rollout_test.py
+++ b/waymax/env/rollout_test.py
@@ -96,7 +96,7 @@ class UtilsTest(tf.test.TestCase, parameterized.TestCase):
       logged_next_traj = datatypes.dynamic_slice(
           state.log_trajectory, state.timestep + 1, 1, axis=-1
       )
-      combined_traj = jax.tree_map(
+      combined_traj = jax.tree_util.tree_map(
           lambda x, y: jnp.concatenate([x, y], axis=-1),
           prev_sim_traj,
           logged_next_traj,

--- a/waymax/env/wrappers/brax_wrapper_test.py
+++ b/waymax/env/wrappers/brax_wrapper_test.py
@@ -71,7 +71,7 @@ class BraxWrapperTest(parameterized.TestCase, tf.test.TestCase):
   def test_step_advances_timestep(self, multi=False):
     env = self.multi_env if multi else self.single_env
     reset_ts = env.reset(self.state_0)
-    action = jax.tree_map(
+    action = jax.tree_util.tree_map(
         lambda x: jnp.zeros(x.shape, dtype=x.dtype), env.action_spec()
     )
     next_ts = env.step(reset_ts, action)
@@ -86,14 +86,14 @@ class BraxWrapperTest(parameterized.TestCase, tf.test.TestCase):
         data_format=_config.DataFormat.TFRECORD,
     )
     dataset_iter = dataloader.simulator_state_generator(config)
-    action = jax.tree_map(
+    action = jax.tree_util.tree_map(
         lambda x: jnp.zeros(x.shape, dtype=x.dtype),
         self.multi_env.action_spec(),
     )
     # Adding batch dimensions if needed.
     for ndims in reversed(batch_dims):
       # pylint: disable=cell-var-from-loop
-      action = jax.tree_map(
+      action = jax.tree_util.tree_map(
           lambda x: jnp.repeat(x[jnp.newaxis], ndims, axis=0), action
       )
     new_state = self.multi_env.reset(next(dataset_iter))

--- a/waymax/visualization/viz.py
+++ b/waymax/visualization/viz.py
@@ -339,7 +339,7 @@ def plot_observation(
     obs = jax.tree_util.tree_map(lambda x: x[batch_idx], obs)
 
   # Shape: (obs_A,) -> ()
-  obs = jax.tree_map(lambda x: x[obj_idx], obs)
+  obs = jax.tree_util.tree_map(lambda x: x[obj_idx], obs)
   if obs.shape:
     raise ValueError(f'Expecting shape () for obs, got {obs.shape}')
 


### PR DESCRIPTION
Fixes:
```
AttributeError: jax.tree_map was removed in JAX v0.6.0: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).
```

following the [Jax 0.6.0 release](https://github.com/jax-ml/jax/releases/tag/jax-v0.6.0).

Context: bumping jax to 0.6.0 in nixpkgs (https://github.com/NixOS/nixpkgs/pull/399406)
