### PR TITLE
Fix make_sdc_dm_environment missing sim_agent_params (#72)

### DIFF
--- a/waymax/env/wrappers/dm_env_wrapper.py
+++ b/waymax/env/wrappers/dm_env_wrapper.py
@@ -191,6 +191,7 @@ def make_sdc_dm_environment(
     dynamics_model: dynamics.DynamicsModel,
     data_config: _config.DatasetConfig,
     env_config: _config.EnvironmentConfig,
+    sim_agent_params: tuple[datatypes.PyTree | None, ...] | None = None,
 ) -> DMEnvWrapper:
   """Makes a DM environment for controlling SDC only.
 
@@ -198,6 +199,9 @@ def make_sdc_dm_environment(
     dynamics_model: A dynamics model used to transit state of the environment.
     data_config: Config for dataset, see details in config.DatasetConfig
     env_config: Config for environment, see details in config.EnvironmentConfig.
+    sim_agent_params: Optional parameters for each sim agent. If None, defaults
+      to (None,) for each sim agent actor. Must match the number of sim agents
+      if provided.
 
   Returns:
     The single agent (SDC) Waymax DM environment that has not been reset.
@@ -213,10 +217,15 @@ def make_sdc_dm_environment(
     ]
   else:
     sim_agent_actors = []
+
+  if sim_agent_params is None:
+    sim_agent_params = (None,) * len(sim_agent_actors)
+  
   dataset_iterator = dataloader.simulator_state_generator(config=data_config)
   single_env = planning_agent_environment.PlanningAgentEnvironment(
       dynamics_model=dynamics_model,
       config=env_config,
       sim_agent_actors=sim_agent_actors,
+      sim_agent_params=sim_agent_params
   )
   return DMEnvWrapper(dataset_iterator, single_env)

--- a/waymax/env/wrappers/dm_env_wrapper_test.py
+++ b/waymax/env/wrappers/dm_env_wrapper_test.py
@@ -56,6 +56,18 @@ class WaymaxDMEnvTest(parameterized.TestCase):
         dataset_iter, self.single_stateless_env
     )
 
+  def _env_config_with_one_sim_agent(self):
+    return _config.EnvironmentConfig(
+      controlled_object=_config.ObjectType.SDC,
+      sim_agents=(
+        _config.SimAgentConfig(
+          agent_type=_config.SimAgentType.IDM,
+          controlled_objects=_config.ObjectType.NON_SDC
+        ),
+      ),
+      max_num_objects=32
+    )
+
   @parameterized.parameters(True, False)
   def test_observation_matches_spec(self, multiagent: bool):
     env = self.multi_env if multiagent else self.single_env
@@ -218,6 +230,45 @@ class WaymaxDMEnvTest(parameterized.TestCase):
     obs_spec = env.observation_spec()
     observation = env.reset().observation
     self.assertEqual(batch_dims + obs_spec.shape, observation.shape)
+
+  def test_make_sdc_dm_env_defaults_sim_agent_params(self):
+    batch_dims = (1,)
+    dynamics_model = dynamics.DeltaGlobal()
+    max_num_objects = 32
+    env_config = self._env_config_with_one_sim_agent()
+    dataset_config = _config.DatasetConfig(
+        path=_TEST_DATA_PATH,
+        data_format=_config.DataFormat.TFRECORD,
+        max_num_objects=max_num_objects,
+        batch_dims=batch_dims,
+    )
+    env = dm_env_wrapper.make_sdc_dm_environment(
+      dynamics_model=dynamics_model,
+      data_config=dataset_config,
+      env_config=env_config,
+      sim_agent_params=None
+    )
+
+    _ = env.reset()
+
+  def test_make_sdc_dm_environment_raises_on_mismatched_sim_agent_params(self):
+    max_num_objects = 32
+    dataset_config = _config.DatasetConfig(
+        path=_TEST_DATA_PATH,
+        data_format=_config.DataFormat.TFRECORD,
+        max_num_objects=max_num_objects,
+        batch_dims=(1,),
+    )
+    env_config = self._env_config_with_one_sim_agent()
+
+    with self.assertRaises(ValueError):
+      _ = dm_env_wrapper.make_sdc_dm_environment(
+          dynamics_model=dynamics.DeltaGlobal(),
+          data_config=dataset_config,
+          env_config=env_config,
+          sim_agent_params=(),
+      )
+  
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
make_sdc_dm_environment was not passing sim_agent_params to
PlanningAgentEnvironment, causing a ValueError when sim agents
were configured. Default to (None,) for each sim agent when
sim_agent_params is not provided