### PR TITLE
Update tutorial notebooks to use WOD 1.3.0 configs

### DIFF
--- a/docs/notebooks/data_demo.ipynb
+++ b/docs/notebooks/data_demo.ipynb
@@ -38,9 +38,9 @@
       },
       "source": [
         "\n",
-        "We first create a dataset config, using the default configs provided in the `waymax.config` module. In particular, `config.WOD_1_1_0_TRAINING` is a pre-defined configuration that points to version 1.1.0 of the Waymo Open Dataset.\n",
+        "We first create a dataset config, using the default configs provided in the `waymax.config` module. In particular, `config.WOD_1_3_0_TRAINING` is a pre-defined configuration that points to version 1.3.0 of the Waymo Open Dataset.\n",
         "\n",
-        "The data config contains a number of options to configure how and where the dataset is loaded from. By default, the `WOD_1_1_0_TRAINING` loads up to 128 objects (e.g. vehicles, pedestrians) per scenario. Here, we can save memory and compute by loading only the first 32 objects stored in the scenario.\n",
+        "The data config contains a number of options to configure how and where the dataset is loaded from. By default, the `WOD_1_3_0_TRAINING` loads up to 128 objects (e.g. vehicles, pedestrians) per scenario. Here, we can save memory and compute by loading only the first 32 objects stored in the scenario.\n",
         "\n",
         "We use the `dataloader.simulator_state_generator` function to create an iterator\n",
         "through Open Motion Dataset scenarios. Calling next on the iterator will retrieve the first scenario in the dataset.\n"
@@ -54,7 +54,7 @@
       },
       "outputs": [],
       "source": [
-        "config = dataclasses.replace(_config.WOD_1_1_0_TRAINING, max_num_objects=32)\n",
+        "config = dataclasses.replace(_config.WOD_1_3_0_TRAINING, max_num_objects=32)\n",
         "data_iter = dataloader.simulator_state_generator(config=config)\n",
         "scenario = next(data_iter)"
       ]

--- a/docs/notebooks/multi_actors_demo.ipynb
+++ b/docs/notebooks/multi_actors_demo.ipynb
@@ -47,7 +47,7 @@
         "max_num_objects = 32\n",
         "\n",
         "config = dataclasses.replace(\n",
-        "    _config.WOD_1_0_0_VALIDATION, max_num_objects=max_num_objects\n",
+        "    _config.WOD_1_3_0_VALIDATION, max_num_objects=max_num_objects\n",
         ")\n",
         "data_iter = dataloader.simulator_state_generator(config=config)\n",
         "scenario = next(data_iter)"


### PR DESCRIPTION
Fixes #90.

This PR updates tutorial notebook dataset config references to use WOD 1.3.0 presets, matching the issue request and making these tutorials easier to run with WOD 1.3.0 data.

### Changes
- `docs/notebooks/data_demo.ipynb`
  - `_config.WOD_1_1_0_TRAINING` -> `_config.WOD_1_3_0_TRAINING`
  - accompanying text updated from version 1.1.0 to 1.3.0
- `docs/notebooks/multi_actors_demo.ipynb`
  - `_config.WOD_1_0_0_VALIDATION` -> `_config.WOD_1_3_0_VALIDATION`

### Notes
- This change only updates tutorial references to existing dataset presets; no library/runtime behavior is modified.
- If maintainers prefer using the latest Motion dataset presets across tutorials, I can switch these refs to `WOD_1_3_1_*` in this PR.
